### PR TITLE
Deleted AssertionError throw

### DIFF
--- a/GeoFirestoreExample/geofirestore/src/main/java/org/imperiumlabs/geofirestore/GeoQuery.java
+++ b/GeoFirestoreExample/geofirestore/src/main/java/org/imperiumlabs/geofirestore/GeoQuery.java
@@ -305,8 +305,6 @@ public class GeoQuery {
         GeoPoint location = GeoFirestore.getLocationValue(documentSnapshot);
         if (location != null) {
             this.updateLocationInfo(documentSnapshot, location);
-        } else {
-            throw new AssertionError("Got DocumentSnapshot without location with key " + documentSnapshot.getId());
         }
     }
 
@@ -314,8 +312,6 @@ public class GeoQuery {
         GeoPoint location = GeoFirestore.getLocationValue(documentSnapshot);
         if (location != null) {
             this.updateLocationInfo(documentSnapshot, location);
-        } else {
-            throw new AssertionError("Got DocumentSnapshot without location with key " + documentSnapshot.getId());
         }
     }
 


### PR DESCRIPTION
Deleting assertionError throw resolved for me issue  #16 and now even if one or more documents have DocumentSnapshow without location, valid documents are loaded without errors as ios version of library do. 