### PR TITLE
Add ability to get queries from GeoQuery

### DIFF
--- a/GeoFirestoreExample/geofirestore/src/main/java/org/imperiumlabs/geofirestore/GeoQuery.java
+++ b/GeoFirestoreExample/geofirestore/src/main/java/org/imperiumlabs/geofirestore/GeoQuery.java
@@ -400,6 +400,11 @@ public class GeoQuery {
         }
     }
 
+    /**
+     * Get the Firestore query(s) for this GeoQuery.
+     *
+     * @return The Firestore query(s) for this GeoQuery
+     */
     public ArrayList<Query> getQueries() {
         Set<GeoHashQuery> oldQueries = (queries == null) ? new HashSet<GeoHashQuery>() : queries;
         Set<GeoHashQuery> newQueries = GeoHashQuery.queriesAtLocation(new GeoLocation(center.getLatitude(), center.getLongitude()), radius);

--- a/GeoFirestoreExample/geofirestore/src/main/java/org/imperiumlabs/geofirestore/GeoQuery.java
+++ b/GeoFirestoreExample/geofirestore/src/main/java/org/imperiumlabs/geofirestore/GeoQuery.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
 
 import javax.annotation.Nullable;
 
@@ -397,6 +398,36 @@ public class GeoQuery {
                 });
             }
         }
+    }
+
+    public ArrayList<Query> getQueries() {
+        Set<GeoHashQuery> oldQueries = (queries == null) ? new HashSet<GeoHashQuery>() : queries;
+        Set<GeoHashQuery> newQueries = GeoHashQuery.queriesAtLocation(new GeoLocation(center.getLatitude(), center.getLongitude()), radius);
+        this.queries = newQueries;
+
+        for (GeoHashQuery query: oldQueries) {
+            if (!newQueries.contains(query)) {
+                GeoHashQueryListener handle = handles.get(firestoreQueries.get(query));
+                if (handle != null) {
+                    handle.childAddedListener.remove();
+                    handle.childRemovedListener.remove();
+                    handle.childChangedListener.remove();
+                }
+                firestoreQueries.remove(query);
+                outstandingQueries.remove(query);
+            }
+        }
+
+        ArrayList<Query> queries = new ArrayList<Query>();
+        for (final GeoHashQuery query: newQueries) {
+            if (!oldQueries.contains(query)) {
+                outstandingQueries.add(query);
+                CollectionReference collectionReference = this.geoFirestore.getCollectionReference();
+                Query firestoreQuery = collectionReference.orderBy("g").startAt(query.getStartValue()).endAt(query.getEndValue());
+                queries.add(firestoreQuery);
+            }
+        }
+        return queries;
     }
 
     /**


### PR DESCRIPTION
I needed a way to get the plain Firestore queries so that I could query them once (rather than listen). I also went this route due to issue #7 . This simply exposes the query (or queries) that the GeoQuery would listen to.

**Usage:**
```kotlin
val queries = geoFirestore.queryAtLocation(GeoPoint(latitude, longitude), radius).queries
queries.forEach {
   it.get()?.addOnSuccessListener { 
     // Do work here
  }?.addOnFailureListener {  }
}